### PR TITLE
Added support for custom ansible inventory and invoking playbooks as specific user

### DIFF
--- a/snaps_common/ansible_snaps/ansible_utils.py
+++ b/snaps_common/ansible_snaps/ansible_utils.py
@@ -29,7 +29,7 @@ logger = logging.getLogger('ansible_utils')
 
 def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
                    ssh_priv_key_file_path=None, password=None, variables=None,
-                   proxy_setting=None):
+                   proxy_setting=None, inventory_cfg=None):
     """
     Executes an Ansible playbook to the given host
     :param playbook_path: the (relative) path to the Ansible playbook
@@ -48,6 +48,8 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
     :param variables: a dictionary containing any substitution variables needed
                       by the Jinga 2 templates
     :param proxy_setting: instance of os_credentials.ProxySettings class
+    :param inventory_cfg: dict specifying host/groups where the key is group
+                          name and the value is a list of hosts
     :raises AnsibleException when the return code from the Ansible library is
             not 0
     :return: the return code from the Ansible library only when 0.
@@ -76,12 +78,17 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
     ansible.constants.HOST_KEY_CHECKING = False
 
     loader = DataLoader()
-    inventory = InventoryManager(loader=loader)
-    if hosts_inv:
+    if inventory_cfg:
+        connection = 'ssh'
+        inventory = __create_custom_inventory(loader, inventory_cfg)
+    elif hosts_inv:
+        inventory = InventoryManager(loader=loader)
         for host in hosts_inv:
             inventory.add_host(host=host, group='ungrouped')
         connection = 'ssh'
     else:
+        loader = DataLoader()
+        inventory = InventoryManager(loader=loader)
         connection = 'local'
 
     variable_manager = VariableManager(loader=loader, inventory=inventory)
@@ -128,6 +135,17 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
                 playbook_path, ret_val, connection))
 
     return ret_val
+
+
+def __create_custom_inventory(loader, inventory_cfg):
+    inventory = InventoryManager(loader=loader)
+    for key, values in inventory_cfg.items():
+        if key == '':
+            key = 'ungrouped'
+        if isinstance(values, list):
+            for value in values:
+                inventory.add_host(host=value, group=key)
+    return inventory
 
 
 class AnsibleException(Exception):

--- a/snaps_common/ansible_snaps/ansible_utils.py
+++ b/snaps_common/ansible_snaps/ansible_utils.py
@@ -29,7 +29,7 @@ logger = logging.getLogger('ansible_utils')
 
 def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
                    ssh_priv_key_file_path=None, password=None, variables=None,
-                   proxy_setting=None, inventory_file=None):
+                   proxy_setting=None, inventory_file=None, become_user=None):
     """
     Executes an Ansible playbook to the given host
     :param playbook_path: the (relative) path to the Ansible playbook
@@ -107,13 +107,19 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
                     'become', 'become_method', 'become_user', 'verbosity',
                     'check', 'timeout', 'diff'])
 
+    become = None
+    become_method = None
+    if become_user:
+        become = 'yes'
+        become_method = 'sudo'
+
     ansible_opts = options(
         listtags=False, listtasks=False, listhosts=False, syntax=False,
         connection=connection, module_path=None, forks=100,
         remote_user=host_user, private_key_file=pk_file_path,
-        ssh_common_args=None, ssh_extra_args=ssh_extra_args, become=None,
-        become_method=None, become_user=None, verbosity=11111, check=False,
-        timeout=30, diff=None)
+        ssh_common_args=None, ssh_extra_args=ssh_extra_args, become=become,
+        become_method=become_method, become_user=become_user, verbosity=11111,
+        check=False, timeout=30, diff=None)
 
     logger.debug('Setting up Ansible Playbook Executor for playbook - ' +
                  playbook_path)

--- a/snaps_common/ansible_snaps/ansible_utils.py
+++ b/snaps_common/ansible_snaps/ansible_utils.py
@@ -142,9 +142,10 @@ def __create_custom_inventory(loader, inventory_cfg):
     for key, values in inventory_cfg.items():
         if key == '':
             key = 'ungrouped'
+        group = inventory.add_group(key)
         if isinstance(values, list):
             for value in values:
-                inventory.add_host(host=value, group=key)
+                inventory.add_host(host=value, group=group)
     return inventory
 
 

--- a/snaps_common/ansible_snaps/ansible_utils.py
+++ b/snaps_common/ansible_snaps/ansible_utils.py
@@ -29,7 +29,7 @@ logger = logging.getLogger('ansible_utils')
 
 def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
                    ssh_priv_key_file_path=None, password=None, variables=None,
-                   proxy_setting=None, inventory_cfg=None):
+                   proxy_setting=None, inventory_file=None):
     """
     Executes an Ansible playbook to the given host
     :param playbook_path: the (relative) path to the Ansible playbook
@@ -78,9 +78,9 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
     ansible.constants.HOST_KEY_CHECKING = False
 
     loader = DataLoader()
-    if inventory_cfg:
+    if inventory_file:
+        inventory = InventoryManager(loader=loader, sources=inventory_file)
         connection = 'ssh'
-        inventory = __create_custom_inventory(loader, inventory_cfg)
     elif hosts_inv:
         inventory = InventoryManager(loader=loader)
         for host in hosts_inv:
@@ -135,18 +135,6 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
                 playbook_path, ret_val, connection))
 
     return ret_val
-
-
-def __create_custom_inventory(loader, inventory_cfg):
-    inventory = InventoryManager(loader=loader)
-    for key, values in inventory_cfg.items():
-        if key == '':
-            key = 'ungrouped'
-        group = inventory.add_group(key)
-        if isinstance(values, list):
-            for value in values:
-                inventory.add_host(host=value, group=group)
-    return inventory
 
 
 class AnsibleException(Exception):

--- a/snaps_common/ansible_snaps/ansible_utils.py
+++ b/snaps_common/ansible_snaps/ansible_utils.py
@@ -48,8 +48,10 @@ def apply_playbook(playbook_path, hosts_inv=None, host_user=None,
     :param variables: a dictionary containing any substitution variables needed
                       by the Jinga 2 templates
     :param proxy_setting: instance of os_credentials.ProxySettings class
-    :param inventory_cfg: dict specifying host/groups where the key is group
-                          name and the value is a list of hosts
+    :param inventory_file: an inventory file that will supercede the hosts_inv
+    :param become_user: the username on this host that the playbook must run
+                        as. When used, the become_method wil be sudo and
+                        become will be 'yes'
     :raises AnsibleException when the return code from the Ansible library is
             not 0
     :return: the return code from the Ansible library only when 0.


### PR DESCRIPTION
#### What does this PR do?
Adds support for inventory files and executing a playbook as a different user as long as they have passwordless sudo access to the host on which the script is being executed from
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
snaps-kubernetes branch 'log_consolidation' is leveraging these two new apply_playbook function parameters
#### Any background context you want to provide?
snaps-kubernetes was calling the kubespray playbook via an ansible playbook command task which required users of snaps-kuberentes to view two separate logs to determine any issues. These new parameters were added to support calling the kubespray playbooks.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
n/a
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no
