### PR TITLE
ansible_utils not compatible with newly released ansible 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock
 paramiko
 PyYAML
-ansible>=2.4
+ansible>=2.4,<2.8


### PR DESCRIPTION
*** Please feel free to merge as I will be on vacation for the next 10 days ***
#### What does this PR do?
Restricts the ansible version as the API has changed and is no longer compatible with this library.
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
install snaps-boot or snaps-kubernetes using this branch
#### Any background context you want to provide?
Robin Ku found this issue while trying to run snaps-boot
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
n/a
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
n/a
- Does this patch update any configuration files?
no
