### PR TITLE
Changes for K8s upgrade to 1.18.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock
 paramiko
 PyYAML
-ansible>=2.4,<2.8
+ansible==2.9.6


### PR DESCRIPTION
#### What does this PR do?
Update Ansible to 2.9 in order to support kubespray for k8s v1.18

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Deploy snaps-kubernetes v1.5 tagged version along with this PR.

#### Any background context you want to provide?
We're now officially k8s v1.18 certified with this PR.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
#15 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
No
